### PR TITLE
Update historio-plus.csl

### DIFF
--- a/historio-plus.csl
+++ b/historio-plus.csl
@@ -69,7 +69,7 @@
   <macro name="editor">
     <names variable="editor translator">
       <name delimiter=" / " delimiter-precedes-last="always">
-        <name-part name="family" font-variant="small-caps"/>
+        <name-part name="family"/>
       </name>
       <label form="short" prefix=", " plural="never"/>
     </names>


### PR DESCRIPTION
Our current citation guidelines no longer write the last name of editors in small caps when citing an article out of an edited volume, so I deleted the corresponding attribute within the "editor translator" varible

For reference, the current citation guidelines can be found under: https://www.historioplus.at/wp-content/uploads/2025/02/Zitierregeln_Zitir.hplus_.12022025.pdf

The citation guideline, corresponding to the changes I made is the one under "Artikel in Sammelband"